### PR TITLE
Deactivate user

### DIFF
--- a/DeactivateAddSQLQuery.sql
+++ b/DeactivateAddSQLQuery.sql
@@ -11,5 +11,9 @@ ALTER TABLE UserProfile
 
 */
 
-SELECT * FROM UserType
+SELECT * FROM UserProfile
 
+INSERT INTO UserProfile
+       (DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId, IdIsActive)
+      OUTPUT INSERTED.Id
+     VALUES('DougThePug', 'Doug', 'Pug', 'Pug@gmail.com', 2020-09-27, null, 2, 1)

--- a/DeactivateAddSQLQuery.sql
+++ b/DeactivateAddSQLQuery.sql
@@ -13,7 +13,5 @@ ALTER TABLE UserProfile
 
 SELECT * FROM UserProfile
 
-INSERT INTO UserProfile
-       (DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId, IdIsActive)
-      OUTPUT INSERTED.Id
-     VALUES('DougThePug', 'Doug', 'Pug', 'Pug@gmail.com', 2020-09-27, null, 2, 1)
+
+

--- a/DeactivateAddSQLQuery.sql
+++ b/DeactivateAddSQLQuery.sql
@@ -1,0 +1,15 @@
+﻿/*
+//This is the Alter required on UserProfile to implement deactivation of users
+
+ALTER TABLE UserProfile
+	ADD IdIsActive Integer
+
+	//Run this update to set all of your users to active (1 is deactivated)
+
+	UPDATE UserProfile
+		SET IdIsActive = 0
+
+*/
+
+SELECT * FROM UserType
+

--- a/SQL/01_TabloidMVC_Create_DB.sql
+++ b/SQL/01_TabloidMVC_Create_DB.sql
@@ -35,6 +35,7 @@ CREATE TABLE [UserProfile] (
   [CreateDateTime] datetime NOT NULL,
   [ImageLocation] nvarchar(255),
   [UserTypeId] integer NOT NULL,
+  [IdIsActive] integer NOT NULL,
 
   CONSTRAINT [FK_User_UserType] FOREIGN KEY ([UserTypeId]) REFERENCES [UserType] ([Id])
 )

--- a/SQL/02_TabloidMVC_Seed_Data.sql
+++ b/SQL/02_TabloidMVC_Seed_Data.sql
@@ -21,8 +21,8 @@ SET IDENTITY_INSERT [Tag] OFF
 
 SET IDENTITY_INSERT [UserProfile] ON
 INSERT INTO [UserProfile] (
-	[Id], [FirstName], [LastName], [DisplayName], [Email], [CreateDateTime], [ImageLocation], [UserTypeId])
-VALUES (1, 'Admina', 'Strator', 'admin', 'admin@example.com', SYSDATETIME(), NULL, 1);
+	[Id], [FirstName], [LastName], [DisplayName], [Email], [CreateDateTime], [ImageLocation], [UserTypeId], [IdIsActive])
+VALUES (1, 'Admina', 'Strator', 'admin', 'admin@example.com', SYSDATETIME(), NULL, 1, 0);
 SET IDENTITY_INSERT [UserProfile] OFF
 
 SET IDENTITY_INSERT [Post] ON

--- a/TabloidMVC/Controllers/AccountController.cs
+++ b/TabloidMVC/Controllers/AccountController.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.AspNetCore.Authentication;
+﻿
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -19,10 +21,38 @@ namespace TabloidMVC.Controllers
             _userProfileRepository = userProfileRepository;
         }
 
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult Create(UserProfile profile)
+        {
+            profile.CreateDateTime = DateTime.Now;
+            profile.IdIsActive = 0;
+            profile.UserTypeId = 2;
+            var credentials = new Credentials()
+            {
+                Email = profile.Email
+            };
+            try
+            {
+                _userProfileRepository.AddNew(profile);
+                return RedirectToAction("NewAccount", "Account", credentials);
+            }
+            catch
+            {
+                return View(profile);
+            }
+        }
         public IActionResult Login()
         {
             return View();
         }
+
+
 
         [HttpPost]
         public async Task<IActionResult> Login(Credentials credentials)
@@ -50,6 +80,36 @@ namespace TabloidMVC.Controllers
             {
                 claims.Add(new Claim(ClaimTypes.Role, "Admin"));
             }
+
+            var claimsIdentity = new ClaimsIdentity(
+                claims, CookieAuthenticationDefaults.AuthenticationScheme);
+
+            await HttpContext.SignInAsync(
+                CookieAuthenticationDefaults.AuthenticationScheme,
+                new ClaimsPrincipal(claimsIdentity));
+
+            return RedirectToAction("Index", "Home");
+        }
+
+        public async Task<IActionResult> NewAccount(Credentials credentials)
+        {
+            var userProfile = _userProfileRepository.GetByEmail(credentials.Email);
+
+            if (userProfile == null)
+            {
+                ModelState.AddModelError("Email", "Invalid email");
+                return View();
+            }
+            //Checks to see if the account has been deactivated
+            else if (userProfile.IdIsActive == 1)
+            {
+                return RedirectToAction("Deactivated", "Account");
+            }
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, userProfile.Id.ToString()),
+                new Claim(ClaimTypes.Email, userProfile.Email),
+            };
 
             var claimsIdentity = new ClaimsIdentity(
                 claims, CookieAuthenticationDefaults.AuthenticationScheme);

--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -54,26 +54,7 @@ namespace TabloidMVC.Controllers
             return View(user);
         }
 
-        // GET: ProfileController/Create
-        public ActionResult Create()
-        {
-            return View();
-        }
-
-        // POST: ProfileController/Create
-        [HttpPost]
-        [ValidateAntiForgeryToken]
-        public ActionResult Create(IFormCollection collection)
-        {
-            try
-            {
-                return RedirectToAction(nameof(Index));
-            }
-            catch
-            {
-                return View();
-            }
-        }
+        
 
         // GET: ProfileController/Edit/5
         public ActionResult Edit(int id)
@@ -159,26 +140,6 @@ namespace TabloidMVC.Controllers
                 }
         }
 
-        // GET: ProfileController/Delete/5
-        public ActionResult Delete(int id)
-        {
-            return View();
-        }
-
-        // POST: ProfileController/Delete/5
-        [HttpPost]
-        [ValidateAntiForgeryToken]
-        public ActionResult Delete(int id, IFormCollection collection)
-        {
-            try
-            {
-                return RedirectToAction(nameof(Index));
-            }
-            catch
-            {
-                return View();
-            }
-        }
         private int GetCurrentUserProfileId()
         {
             string id = User.FindFirstValue(ClaimTypes.NameIdentifier);

--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -27,6 +27,10 @@ namespace TabloidMVC.Controllers
         //GET only active users and list
         public IActionResult Index()
         {
+            if (!_userProfileRepository.VerifyAdminStatus(GetCurrentUserProfileId()))
+            {
+                return RedirectToAction("AccountChangedRecently", "UserProfile");
+            }
             List<UserProfile> users = _userProfileRepository.GetAllUsers(0); 
             return View(users);
         }
@@ -35,6 +39,10 @@ namespace TabloidMVC.Controllers
 
         public IActionResult ShowDeactivated()
         {
+            if (!_userProfileRepository.VerifyAdminStatus(GetCurrentUserProfileId()))
+            {
+                return RedirectToAction("AccountChangedRecently", "UserProfile");
+            }
             List<UserProfile> deactivatedUsers = _userProfileRepository.GetAllUsers(1);
             if (deactivatedUsers.Count == 0)
             {
@@ -46,6 +54,7 @@ namespace TabloidMVC.Controllers
         // GET: ProfileController/Details/5
         public ActionResult Details(int id)
         {
+            Verify();
             var user = _userProfileRepository.GetById(id);
             if (user == null)
             {
@@ -59,6 +68,10 @@ namespace TabloidMVC.Controllers
         // GET: ProfileController/Edit/5
         public ActionResult Edit(int id)
         {
+            if (!_userProfileRepository.VerifyAdminStatus(GetCurrentUserProfileId()))
+            {
+                return RedirectToAction("AccountChangedRecently", "UserProfile");
+            }
             var vm = new UserProfileAdminEditViewModel()
             {
                 Profile = _userProfileRepository.GetById(id),
@@ -187,6 +200,16 @@ namespace TabloidMVC.Controllers
         public ActionResult AdminError()
         {
             return View();
+        }
+
+        public ActionResult Verify()
+        {
+            if (!_userProfileRepository.VerifyAdminStatus(GetCurrentUserProfileId()))
+            {
+                return RedirectToAction("AccountChangedRecently", "UserProfile");
+            }
+
+            return null;
         }
     }
 }

--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -31,6 +31,7 @@ namespace TabloidMVC.Controllers
             {
                 return RedirectToAction("AccountChangedRecently", "UserProfile");
             }
+            //Gets list of Active users. Arg of 0 is for UserProfile.IdIsActive, 0 = Active
             List<UserProfile> users = _userProfileRepository.GetAllUsers(0); 
             return View(users);
         }
@@ -43,6 +44,7 @@ namespace TabloidMVC.Controllers
             {
                 return RedirectToAction("AccountChangedRecently", "UserProfile");
             }
+            //Gets list of Active users. Arg of 1 is for UserProfile.IdIsActive, 1 = Deactivated
             List<UserProfile> deactivatedUsers = _userProfileRepository.GetAllUsers(1);
             if (deactivatedUsers.Count == 0)
             {

--- a/TabloidMVC/Models/Post.cs
+++ b/TabloidMVC/Models/Post.cs
@@ -19,6 +19,7 @@ namespace TabloidMVC.Models
 
         public DateTime CreateDateTime { get; set; }
 
+        [Required]
         [DisplayName("Published")]
         [DataType(DataType.Date)]
         public DateTime? PublishDateTime { get; set; }

--- a/TabloidMVC/Models/UserProfile.cs
+++ b/TabloidMVC/Models/UserProfile.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Data.SqlClient.Server;
 using System;
+using System.ComponentModel;
 using System.Runtime.Intrinsics.X86;
 
 namespace TabloidMVC.Models
@@ -7,14 +8,33 @@ namespace TabloidMVC.Models
     public class UserProfile
     {
         public int Id { get; set; }
+
+        [DisplayName("First Name")]
         public string FirstName { get; set; }
+
+        [DisplayName("Last Name")]
         public string LastName { get; set; }
+
+        [DisplayName("Display Name")]
         public string DisplayName { get; set; }
+
+        [DisplayName("Email Address")]
         public string Email { get; set; }
+
+        [DisplayName("Account created on")]
         public DateTime CreateDateTime { get; set; }
+
+        [DisplayName("Picture")]
         public string ImageLocation { get; set; }
+
         public int UserTypeId { get; set; }
+
+        [DisplayName("Account status")]
+        public int IdIsActive { get; set; }
+
+        [DisplayName("User Role")]
         public UserType UserType { get; set; }
+        [DisplayName("Full Name")]
         public string FullName
         {
             get

--- a/TabloidMVC/Models/UserProfile.cs
+++ b/TabloidMVC/Models/UserProfile.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Data.SqlClient.Server;
 using System;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Runtime.Intrinsics.X86;
 
 namespace TabloidMVC.Models
@@ -8,16 +9,17 @@ namespace TabloidMVC.Models
     public class UserProfile
     {
         public int Id { get; set; }
-
+        [Required]
         [DisplayName("First Name")]
         public string FirstName { get; set; }
-
+        [Required]
         [DisplayName("Last Name")]
         public string LastName { get; set; }
-
+        [Required]
         [DisplayName("Display Name")]
         public string DisplayName { get; set; }
-
+        [Required]
+        [DataType(DataType.EmailAddress)]
         [DisplayName("Email Address")]
         public string Email { get; set; }
 

--- a/TabloidMVC/Models/ViewModels/UserProfileAdminEditViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/UserProfileAdminEditViewModel.cs
@@ -9,5 +9,6 @@ namespace TabloidMVC.Models.ViewModels
     {
         public UserProfile Profile { get; set; }
         public List<UserType> Types { get; set; }
+        
     }
 }

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -13,5 +13,6 @@ namespace TabloidMVC.Repositories
         List<UserProfile> CheckForAdmins();
         List<UserProfile> CheckForActiveAdmins();
         bool VerifyAdminStatus(int id);
+        void AddNew(UserProfile profile);
     }
 }

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -6,10 +6,12 @@ namespace TabloidMVC.Repositories
     public interface IUserProfileRepository
     {
         UserProfile GetByEmail(string email);
-        List<UserProfile> GetAllUsers();
+        List<UserProfile> GetAllUsers(int IsActive);
         UserProfile GetById(int id);
         List<UserType> GetAllTypes();
         void UpdateUserProfile(UserProfile profile);
         List<UserProfile> CheckForAdmins();
+        List<UserProfile> CheckForActiveAdmins();
+        bool VerifyAdminStatus(int id);
     }
 }

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -216,6 +216,35 @@ namespace TabloidMVC.Repositories
             }
         }
 
+        public void AddNew(UserProfile profile)
+        {
+            using(SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                                        INSERT INTO UserProfile
+                                                (DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId, IdIsActive)
+                                            OUTPUT INSERTED.Id
+                                                VALUES(@DisplayName, @FirstName, @LastName, @Email, @CreateDateTime, @ImageLocation, @UserTypeId, @IdIsActive)";
+                    cmd.Parameters.AddWithValue("@DisplayName", profile.DisplayName);
+                    cmd.Parameters.AddWithValue("@FirstName", profile.FirstName);
+                    cmd.Parameters.AddWithValue("@LastName", profile.LastName);
+                    cmd.Parameters.AddWithValue("@Email", profile.Email);
+                    cmd.Parameters.AddWithValue("@CreateDateTime", profile.CreateDateTime);
+                    cmd.Parameters.AddWithValue("@ImageLocation", profile.ImageLocation);
+                    cmd.Parameters.AddWithValue("@UserTypeId", profile.UserTypeId);
+                    cmd.Parameters.AddWithValue("@IdIsActive", profile.IdIsActive);
+
+                    int id = (int)cmd.ExecuteScalar();
+
+                    profile.Id = id;
+
+                }
+            }
+        }
+
         public void UpdateUserProfile(UserProfile profile)
         {
             using(SqlConnection conn = Connection)

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -129,10 +129,16 @@ namespace TabloidMVC.Repositories
                     cmd.CommandText = @"
                                         SELECT UserTypeId FROM UserProfile
                                             WHERE UserTypeId = 1
-                                            AND IdIsActive = 0";
+                                            AND IdIsActive = 0
+                                            AND Id = @id";
+                    cmd.Parameters.AddWithValue("@id", id);
                     SqlDataReader reader = cmd.ExecuteReader();
 
-                    return reader.Read();                    
+                    if (reader.Read())
+                    {
+                        return true;
+                    }
+                    return false;                    
                 }
 
             }

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
+using System;
 using System.Collections.Generic;
 using TabloidMVC.Models;
 using TabloidMVC.Utils;
@@ -239,9 +240,18 @@ namespace TabloidMVC.Repositories
                     cmd.Parameters.AddWithValue("@LastName", profile.LastName);
                     cmd.Parameters.AddWithValue("@Email", profile.Email);
                     cmd.Parameters.AddWithValue("@CreateDateTime", profile.CreateDateTime);
-                    cmd.Parameters.AddWithValue("@ImageLocation", profile.ImageLocation);
                     cmd.Parameters.AddWithValue("@UserTypeId", profile.UserTypeId);
                     cmd.Parameters.AddWithValue("@IdIsActive", profile.IdIsActive);
+                    //Checks for Null value in image location
+                    if (!string.IsNullOrWhiteSpace(profile.ImageLocation))
+                    {
+                        cmd.Parameters.AddWithValue("@ImageLocation", profile.ImageLocation);
+                    }
+                    else
+                    {
+                        cmd.Parameters.AddWithValue("@ImageLocation", DBNull.Value);
+                    }
+
 
                     int id = (int)cmd.ExecuteScalar();
 

--- a/TabloidMVC/Views/Account/AccountNewlyDeactivated.cshtml
+++ b/TabloidMVC/Views/Account/AccountNewlyDeactivated.cshtml
@@ -1,0 +1,21 @@
+﻿
+@{
+    ViewData["Title"] = "AccountNewlyDeactivated";
+}
+
+<div class="container pt-5">
+    <div class="row justify-content-center">
+        <div class="card col-sm-12 col-md-6 col-lg-4">
+            <h1 class="text-center" style="font-size: 100px">
+                <i class="fas fa-user-circle text-primary"></i>
+            </h1>
+            <div class="card-body">
+                <h2 class="card-title text-center text-secondary">We're sorry, this account has been deactivated</h2>
+                <div class="row justify-content-center">
+                    <a class="btn btn-primary btn-lg" asp-controller="account" asp-action="login">LOGIN</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/TabloidMVC/Views/Account/Create.cshtml
+++ b/TabloidMVC/Views/Account/Create.cshtml
@@ -1,0 +1,54 @@
+﻿@model TabloidMVC.Models.UserProfile
+
+@{
+    ViewData["Title"] = "Create";
+}
+
+<div class="container pt-5">
+    <h1>Register</h1>
+
+    <hr />
+    <div class="row">
+        <div class="col-md-4">
+            <form asp-action="Create">
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div class="form-group">
+                    <label asp-for="FirstName" class="control-label"></label>
+                    <input asp-for="FirstName" class="form-control" />
+                    <span asp-validation-for="FirstName" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="LastName" class="control-label"></label>
+                    <input asp-for="LastName" class="form-control" />
+                    <span asp-validation-for="LastName" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="DisplayName" class="control-label"></label>
+                    <input asp-for="DisplayName" class="form-control" />
+                    <span asp-validation-for="DisplayName" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="Email" class="control-label"></label>
+                    <input asp-for="Email" class="form-control" />
+                    <span asp-validation-for="Email" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="ImageLocation" class="control-label"></label>
+                    <input asp-for="ImageLocation" class="form-control" />
+                    <span asp-validation-for="ImageLocation" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <input type="submit" value="Create" class="btn btn-primary" />
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div>
+        <a asp-controller="Home" asp-action="Index">Home</a>
+    </div>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/TabloidMVC/Views/Account/Deactivated.cshtml
+++ b/TabloidMVC/Views/Account/Deactivated.cshtml
@@ -1,0 +1,22 @@
+﻿
+@{
+    ViewData["Title"] = "Deactivated";
+}
+
+<div class="container pt-5">
+    <div class="row justify-content-center">
+        <div class="card col-sm-12 col-md-6 col-lg-4">
+            <h1 class="text-center" style="font-size: 100px">
+                <i class="fas fa-user-circle text-primary"></i>
+            </h1>
+            <div class="card-body">
+                <h2 class="card-title text-center text-secondary">We're sorry, The requested account has been deactivated</h2>
+                <div class="row justify-content-center">
+                    <a class="btn btn-primary btn-lg" asp-controller="account" asp-action="login">LOGIN</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+

--- a/TabloidMVC/Views/Account/DemotedToAuthor.cshtml
+++ b/TabloidMVC/Views/Account/DemotedToAuthor.cshtml
@@ -1,0 +1,20 @@
+﻿
+@{
+    ViewData["Title"] = "DemotedToAuthor";
+}
+
+<div class="container pt-5">
+    <div class="row justify-content-center">
+        <div class="card col-sm-12 col-md-6 col-lg-4">
+            <h1 class="text-center" style="font-size: 100px">
+                <i class="fas fa-user-circle text-primary"></i>
+            </h1>
+            <div class="card-body">
+                <h2 class="card-title text-center text-secondary">We're sorry, this account no longer has admin access</h2>
+                <div class="row justify-content-center">
+                    <a class="btn btn-primary btn-lg" asp-controller="Home" asp-action="Index">Home</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -27,7 +27,7 @@
                             @if (User.IsInRole("Admin"))
                             {
                                 <li class="nav-item mx-0 mx-lg-1">
-                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="UserProfile" asp-action="Index">User Profiles</a>
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="UserProfile" asp-action="Index">USER PROFILES</a>
                                 </li>
                             }
 
@@ -43,7 +43,7 @@
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">Category Management</a>
                             </li>
-                            
+
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Tags" asp-action="Index">Tag Management</a>
                             </li>
@@ -53,6 +53,9 @@
                         }
                         else
                         {
+                            <li class="nav-item mx-0 mx-lg-1">
+                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Create">REGISTER</a>
+                            </li>
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Login">LOGIN</a>
                             </li>

--- a/TabloidMVC/Views/UserProfile/AdminError.cshtml
+++ b/TabloidMVC/Views/UserProfile/AdminError.cshtml
@@ -1,0 +1,23 @@
+﻿
+@{
+    ViewData["Title"] = "AdminError";
+}
+
+<div class="container pt-5">
+    <div class="row justify-content-center">
+        <div class="card col-sm-12 col-md-6 col-lg-4">
+            <h1 class="text-center" style="font-size: 100px">
+                <i class="fas fa-user-circle text-primary"></i>
+            </h1>
+            <div class="card-body">
+                <h2 class="card-title text-center text-secondary">We're sorry, an error has occured while processing your request.</h2>
+                <div class="row justify-content-center">
+                    <a class="btn btn-primary btn-lg" asp-controller="Home" asp-action="Index">Home</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+

--- a/TabloidMVC/Views/UserProfile/Edit.cshtml
+++ b/TabloidMVC/Views/UserProfile/Edit.cshtml
@@ -29,6 +29,9 @@
                     <th>
                         @Html.DisplayNameFor(model => Model.Profile.UserType.Name)
                     </th>
+                    <th>
+                        @Html.DisplayNameFor(model => Model.Profile.IdIsActive)
+                    </th>
                 </tr>
             </thead>
             <tbody>
@@ -67,6 +70,15 @@
                                 }
                             </select>
                             <span asp-validation-for="Profile.UserTypeId" class="text-danger"></span>
+                        </div>
+                    </td>
+                    <td>
+                        <div class="form-group">
+                            <select asp-for="Profile.IdIsActive" class="form-control">
+                                <option value="0" >Active</option>
+                                <option value="1">Deactivated</option>
+                            </select>
+                            <span asp-validation-for="Profile.IdIsActive" class="text-danger"></span>
                         </div>
                     </td>
                     <td>

--- a/TabloidMVC/Views/UserProfile/Index.cshtml
+++ b/TabloidMVC/Views/UserProfile/Index.cshtml
@@ -7,7 +7,8 @@
 
 
 <div class="container pt-5">
-    <h1>User Profiles</h1>
+    <h1>User Profiles - Active</h1>
+
 
     <table class="table">
         <thead>
@@ -46,12 +47,17 @@
                         <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
                             <i class="fas fa-pencil-alt"></i>
                         </a>
-@*                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
-                            <i class="fas fa-trash"></i>
-                        </a>*@
+                        @*                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                                <i class="fas fa-trash"></i>
+                            </a>*@
                     </td>
                 </tr>
             }
         </tbody>
     </table>
+    <div>
+        <a class="btn btn-primary btn-lg" asp-controller="Home" asp-action="Index">Home</a>
+        <a class="btn btn-primary btn-lg" asp-controller="UserProfile" asp-action="ShowDeactivated">Show Deactivated Accounts</a>
     </div>
+    
+</div>

--- a/TabloidMVC/Views/UserProfile/Index.cshtml
+++ b/TabloidMVC/Views/UserProfile/Index.cshtml
@@ -8,8 +8,6 @@
 
 <div class="container pt-5">
     <h1>User Profiles - Active</h1>
-
-
     <table class="table">
         <thead>
             <tr>

--- a/TabloidMVC/Views/UserProfile/LastAdminDeactivateError.cshtml
+++ b/TabloidMVC/Views/UserProfile/LastAdminDeactivateError.cshtml
@@ -1,0 +1,42 @@
+﻿@model TabloidMVC.Models.UserProfile
+
+@{
+    ViewData["Title"] = "LastAdminDeactivateError";
+}
+
+<div class="container pt-5">
+    <h1>We're Sorry, You may not deactivate the last Admin</h1>
+
+    <table class="table">
+        <thead>
+            <tr>
+
+                <th>
+                    @Html.DisplayNameFor(model => model.FullName)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.DisplayName)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.Email)
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => Model.FullName)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => Model.DisplayName)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => Model.Email)
+                </td>
+                <td>
+                    <a asp-action="Index">Back to List</a>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/TabloidMVC/Views/UserProfile/NoDeactivated.cshtml
+++ b/TabloidMVC/Views/UserProfile/NoDeactivated.cshtml
@@ -1,0 +1,20 @@
+﻿
+@{
+    ViewData["Title"] = "NoDeactivated";
+}
+
+<div class="container pt-5">
+    <div class="row justify-content-center">
+        <div class="card col-sm-12 col-md-6 col-lg-4">
+            <h1 class="text-center" style="font-size: 100px">
+                <i class="fas fa-user-circle text-primary"></i>
+            </h1>
+            <div class="card-body">
+                <h2 class="card-title text-center text-secondary">No deactivated accounts were found</h2>
+                <div class="row justify-content-center">
+                    <a class="btn btn-primary btn-lg" asp-controller="UserProfile" asp-action="Index">Return to User Profiles</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/TabloidMVC/Views/UserProfile/ShowDeactivated.cshtml
+++ b/TabloidMVC/Views/UserProfile/ShowDeactivated.cshtml
@@ -1,0 +1,67 @@
+﻿@model IEnumerable<TabloidMVC.Models.UserProfile>
+
+@{
+    ViewData["Title"] = "ShowDeactivated";
+}
+
+
+
+<div class="container pt-5">
+    <h1>User Profiles - Deactivated</h1>
+
+    <table class="table">
+        <thead>
+            <tr>
+
+                <th>
+                    @Html.DisplayNameFor(model => model.FullName)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.DisplayName)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.UserType.Name)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.IdIsActive)
+                </th>
+
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var item in Model)
+            {
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => item.FullName)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.DisplayName)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.UserType.Name)
+                </td>
+                <td>
+                    Deactivated
+                </td>
+                <td>
+                    <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="View">
+                        <i class="fas fa-eye"></i>
+                    </a>
+                    <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                        <i class="fas fa-pencil-alt"></i>
+                    </a>
+                    @*                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                <i class="fas fa-trash"></i>
+            </a>*@
+                </td>
+            </tr>
+            }
+        </tbody>
+    </table>
+    <div>
+        <a class="btn btn-primary btn-lg" asp-controller="Home" asp-action="Index">Home</a>
+        <a class="btn btn-primary btn-lg" asp-controller="UserProfile" asp-action="Index">Show Active Accounts</a>
+    </div>
+</div>


### PR DESCRIPTION
# Description
Admin accounts may deactivate and reactivate User Profiles (accounts)
Registration of new user is in place.
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
While logged in using an Admin level account, you may access the User Profiles section and edit user profiles. Clicking 'edit' on a profile will bring you to the edit view which allows changing the profile `Role` and, with this PR, allows changing the account status. Setting a profile to deactivated will not allow that account access to the system the next time they try to log in. If the user is currently logged in (and an Admin), the system will boot them as soon as the account tries to access any view in the Admin protected User Profile section. Since we can only run one instance of Tabloid at a time, the only way to test this is to 'Deactivate' the account you are currently using. However, the system will not allow you to deactivate or demote the only remaining active Admin account. You will need to have a sacrificial account set up. 

New user Registration is in place. If logged out, you may register a new user. A successful registration will automatically log the new account into the system.

# Required
You MUST run the following SQL scripts to enable the use of Activate/Deactivate

`ALTER TABLE UserProfile
	ADD IdIsActive Integer`

`UPDATE UserProfile
		SET IdIsActive = 0`
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works