### PR TITLE
fixed back to list bug in create comment field and removed ids from d…

### DIFF
--- a/TabloidMVC/Controllers/CommentController.cs
+++ b/TabloidMVC/Controllers/CommentController.cs
@@ -45,9 +45,11 @@ namespace TabloidMVC.Controllers
         }
 
         // GET: CommentController/Create
-        public ActionResult Create()
+        public ActionResult Create(int id)
         {
-            return View();
+            Comment comment = new Comment();
+            comment.PostId = id;
+            return View(comment);
         }
 
         // POST: CommentController/Create

--- a/TabloidMVC/Controllers/CommentController.cs
+++ b/TabloidMVC/Controllers/CommentController.cs
@@ -27,6 +27,14 @@ namespace TabloidMVC.Controllers
         public ActionResult Index(int id)
         {
             List<Comment> comments = _commentRepository.GetAllCommentsFromPost(id);
+            foreach (Comment comment in comments)
+            {
+                int currentUserId = GetCurrentUserProfileId();
+                if (comment.UserProfileId == currentUserId)
+                {
+                    comment.IsCurrentUser = true;
+                }
+            }
             Post post = _postRepository.GetPublishedPostById(id);
             CommentViewModel cvm = new CommentViewModel
             {

--- a/TabloidMVC/Controllers/CommentController.cs
+++ b/TabloidMVC/Controllers/CommentController.cs
@@ -16,12 +16,15 @@ namespace TabloidMVC.Controllers
     {
         private readonly ICommentRepository _commentRepository;
         private readonly IPostRepository _postRepository;
+        private readonly IUserProfileRepository _userProfileRepository;
         
         public CommentController(ICommentRepository commentRepository, 
-                                    IPostRepository postRepository)
+                                    IPostRepository postRepository,
+                                    IUserProfileRepository userProfileRepository)
         {
             _commentRepository = commentRepository;
             _postRepository = postRepository;
+            _userProfileRepository = userProfileRepository;
         }
         // GET: CommentController
         public ActionResult Index(int id)
@@ -29,6 +32,7 @@ namespace TabloidMVC.Controllers
             List<Comment> comments = _commentRepository.GetAllCommentsFromPost(id);
             foreach (Comment comment in comments)
             {
+                comment.userProfile = _userProfileRepository.GetById(comment.UserProfileId);
                 int currentUserId = GetCurrentUserProfileId();
                 if (comment.UserProfileId == currentUserId)
                 {
@@ -36,6 +40,7 @@ namespace TabloidMVC.Controllers
                 }
             }
             Post post = _postRepository.GetPublishedPostById(id);
+            
             CommentViewModel cvm = new CommentViewModel
             {
                 Comments = comments,

--- a/TabloidMVC/Models/Comment.cs
+++ b/TabloidMVC/Models/Comment.cs
@@ -18,5 +18,7 @@ namespace TabloidMVC.Models
         public DateTime CreateDateTime { get; set; }
 
         public bool IsCurrentUser { get; set; }
+
+        public UserProfile userProfile { get; set; }
     }
 }

--- a/TabloidMVC/Models/Comment.cs
+++ b/TabloidMVC/Models/Comment.cs
@@ -16,5 +16,7 @@ namespace TabloidMVC.Models
 
         [DisplayFormat(DataFormatString = "{0:MM/dd/yyyy}")]
         public DateTime CreateDateTime { get; set; }
+
+        public bool IsCurrentUser { get; set; }
     }
 }

--- a/TabloidMVC/Models/ViewModels/CommentViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/CommentViewModel.cs
@@ -10,5 +10,7 @@ namespace TabloidMVC.Models.ViewModels
         public List<Comment> Comments { get; set; }
 
         public Post Post { get; set; }
+
+        
     }
 }

--- a/TabloidMVC/Views/Comment/Create.cshtml
+++ b/TabloidMVC/Views/Comment/Create.cshtml
@@ -30,7 +30,7 @@
     </div>
 
     <div>
-        <a asp-action="Index">Back to List</a>
+        <a asp-action="Index" asp-route-id="@Model.PostId">Back to List</a>
     </div>
 
     @section Scripts {

--- a/TabloidMVC/Views/Comment/Delete.cshtml
+++ b/TabloidMVC/Views/Comment/Delete.cshtml
@@ -3,36 +3,39 @@
 @{
     ViewData["Title"] = "Delete";
 }
+<div class="container pt-5">
+    <h1>Delete</h1>
 
-<h1>Delete</h1>
+    <h3>Are you sure you want to delete this?</h3>
+    <div class="row justify-content-center">
+        <div class="card col-md-12 col-lg-8">
+            <h4>Comment</h4>
+            <hr />
 
-<h3>Are you sure you want to delete this?</h3>
-<div>
-    <h4>Comment</h4>
-    <hr />
-    <dl class="row">
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Subject)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Subject)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Content)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Content)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.CreateDateTime)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.CreateDateTime)
-        </dd>
-    </dl>
-    
-    <form asp-action="Delete">
-        <input type="submit" value="Delete" class="btn btn-danger" /> |
-        <a asp-action="Index" asp-route-id="@Model.PostId">Back to List</a>
-    </form>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.Subject)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.Subject)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.Content)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.Content)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.CreateDateTime)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.CreateDateTime)
+            </dd>
+            </dl>
+
+            <form asp-action="Delete">
+                <input type="submit" value="Delete" class="btn btn-danger" /> |
+                <a asp-action="Index" asp-route-id="@Model.PostId">Back to List</a>
+            </form>
+        </div>
+    </div>
 </div>

--- a/TabloidMVC/Views/Comment/Delete.cshtml
+++ b/TabloidMVC/Views/Comment/Delete.cshtml
@@ -12,24 +12,6 @@
     <hr />
     <dl class="row">
         <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Id)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Id)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.PostId)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.PostId)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.UserProfileId)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.UserProfileId)
-        </dd>
-        <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.Subject)
         </dt>
         <dd class = "col-sm-10">

--- a/TabloidMVC/Views/Comment/Index.cshtml
+++ b/TabloidMVC/Views/Comment/Index.cshtml
@@ -37,41 +37,35 @@
 
             @foreach (var item in Model.Comments)
             {
-                if (item.IsCurrentUser)
-                {
+                
 
 
-                    <tr>
-                        <td>
-                            @Html.DisplayFor(modelItem => item.Subject)
-                        </td>
-                        <td>
-                            @Html.DisplayFor(modelItem => item.Content)
-                        </td>
-                        <td>
-                            @Html.DisplayFor(modelItem => item.CreateDateTime)
-                        </td>
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Subject)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Content)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.CreateDateTime)
+                </td>
+                @{
+                    if (item.IsCurrentUser)
+                    {
                         <td>
 
                             @Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
                             @Html.ActionLink("Delete", "Delete", new { id = item.Id })
                         </td>
-                    </tr>
-                }
-                else
-                {
-                    <tr>
+                    } else
+                    {
                         <td>
-                            @Html.DisplayFor(modelItem => item.Subject)
+
                         </td>
-                        <td>
-                            @Html.DisplayFor(modelItem => item.Content)
-                        </td>
-                        <td>
-                            @Html.DisplayFor(modelItem => item.CreateDateTime)
-                        </td>
-                    </tr>
-                }
+                    }
+                 }
+                </tr>
             }
         </tbody>
     </table>

--- a/TabloidMVC/Views/Comment/Index.cshtml
+++ b/TabloidMVC/Views/Comment/Index.cshtml
@@ -34,23 +34,44 @@
             </tr>
         </thead>
         <tbody>
+
             @foreach (var item in Model.Comments)
             {
-                <tr>
-                    <td>
-                        @Html.DisplayFor(modelItem => item.Subject)
-                    </td>
-                    <td>
-                        @Html.DisplayFor(modelItem => item.Content)
-                    </td>
-                    <td>
-                        @Html.DisplayFor(modelItem => item.CreateDateTime)
-                    </td>
-                    <td>
-                        @Html.ActionLink("Edit", "Edit", new { id=item.Id }) |
-                        @Html.ActionLink("Delete", "Delete", new { id=item.Id })
-                    </td>
-                </tr>
+                if (item.IsCurrentUser)
+                {
+
+
+                    <tr>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.Subject)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.Content)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.CreateDateTime)
+                        </td>
+                        <td>
+
+                            @Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
+                            @Html.ActionLink("Delete", "Delete", new { id = item.Id })
+                        </td>
+                    </tr>
+                }
+                else
+                {
+                    <tr>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.Subject)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.Content)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.CreateDateTime)
+                        </td>
+                    </tr>
+                }
             }
         </tbody>
     </table>

--- a/TabloidMVC/Views/Comment/Index.cshtml
+++ b/TabloidMVC/Views/Comment/Index.cshtml
@@ -28,6 +28,9 @@
                     @Html.DisplayNameFor(model => model.Comments[0].Content)
                 </th>
                 <th>
+                    @Html.DisplayNameFor(model => model.Comments[0].userProfile.DisplayName)
+                </th>
+                <th>
                     @Html.DisplayNameFor(model => model.Comments[0].CreateDateTime)
                 </th>
                 <th></th>
@@ -48,6 +51,9 @@
                     @Html.DisplayFor(modelItem => item.Content)
                 </td>
                 <td>
+                    @Html.DisplayFor(modelItem => item.userProfile.DisplayName)
+                </td>
+                <td>
                     @Html.DisplayFor(modelItem => item.CreateDateTime)
                 </td>
                 @{
@@ -58,14 +64,14 @@
                             @Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
                             @Html.ActionLink("Delete", "Delete", new { id = item.Id })
                         </td>
-                    } else
+                    }
+                    else
                     {
                         <td>
-
                         </td>
                     }
-                 }
-                </tr>
+                }
+            </tr>
             }
         </tbody>
     </table>


### PR DESCRIPTION
# Description
This branch fixes the bug that arose when the user attempted to navigate back to the main list of comments from the comment creation view.  It also prevents the user from being able to see edit or delete buttons that they should not see.  It also displays the comment author name
Fixes # (issue)
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
# Testing Instructions
Pull down this branch.  Verify that all previously function comment features are still working.  Attempt to create a new comment.  Change your mind.  Click "back to list"; verify that you are navigated back to the post-appropriate list of comments.  verify that you cannot edit or delete other peoples comments
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works